### PR TITLE
Moving responsibility down to childs

### DIFF
--- a/lib/Expressions/arity1_operators.rb
+++ b/lib/Expressions/arity1_operators.rb
@@ -13,11 +13,4 @@ class Arity1Operators < Operator
 
   alias_method :equal?, :==
 
-  def to_sql
-    if self.is_a? UnaryMinus
-      operand = @operand
-      fail(ArgumentError, ("#{operand} is not a number")) if operand !~ /^\d+$/
-      -operand.to_i
-    end
-  end
 end

--- a/lib/Expressions/operator.rb
+++ b/lib/Expressions/operator.rb
@@ -18,4 +18,9 @@ class Operator
   def self.register(operator_symbol, class_name, precedence)
     OPERATORS[operator_symbol] = { class_name: class_name, precedence: precedence }
   end
+
+  def to_sql
+    raise NotImplementedError
+  end
+
 end

--- a/lib/Expressions/unary_minus.rb
+++ b/lib/Expressions/unary_minus.rb
@@ -1,4 +1,10 @@
 class UnaryMinus < Arity1Operators
   Operator.register('-', UnaryMinus, 3)
 
+  def to_sql
+    operand = @operand
+    fail(ArgumentError, ("#{operand} is not a number")) if operand !~ /^\d+$/
+    -operand.to_i
+  end
+
 end


### PR DESCRIPTION
### I'm proposing this change because of following reasons:

1) "abstract" class `Arity1Operators` shouldn't hold responsibility for its children (because `Arity1Operators` does not know how many children has )
2) It would go against **S.O.L.I.D** (more precisely **open closed principle**), that says "code should be open for addition, but closed for modification". When we want to add new child of `Arity1Operators` we do not have to modify `Arity1Operators`, we just add new class and extend it (so we don't have to maintain switch of children, we let **polymorphism** to figure it out for us).

Also added default implementation of to_sql for all Operators, by default it throws `NotImplementedError`, so we are forced to implement it.
